### PR TITLE
refactor(api): replace hardcoded podcast source strings with PODCAST_…

### DIFF
--- a/src/api/listenlater/listen_later.ts
+++ b/src/api/listenlater/listen_later.ts
@@ -8,12 +8,13 @@ import { UserListenLaterDto } from "../../models/listen_later";
 import { queryUserListenLaterList, queryUserListenLaterTotalCount } from "../../db/listen_later";
 import { logger } from "../../utils/logger";
 import { getSpotifyEpisodeDetail } from "../../utils/spotify";
+import { PODCAST_SOURCES } from "../../models/types";
 
 
 export async function addEpisodeToListenLater(request: AddPodcastToListenLaterRequest): Promise<String> {
     let itemInfoResp;
     let feedItem: FeedItem
-    if (request.source == 'itunes') {
+    if (request.source == PODCAST_SOURCES.ITUNES) {
         itemInfoResp = await getPodcastEpisodeInfo(request.channelId, request.itemId)
         feedItem = itemInfoResp.episode
     } else {

--- a/src/api/listenlater/route.ts
+++ b/src/api/listenlater/route.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { AddPodcastToListenLaterRequest } from "./types";
 import { addEpisodeToListenLater, getUserListenLaterList } from "./listen_later";
 import { UserListenLaterDto } from "../../models/listen_later";
+import { PODCAST_SOURCES } from "../../models/types";
 
 export const listenLaterRoute = new Hono()
 
@@ -9,7 +10,7 @@ listenLaterRoute.post('', async (c) => {
     
     const body: AddPodcastToListenLaterRequest = await c.req.json();
     if (!body.source) {
-        body.source = 'itunes'
+        body.source = PODCAST_SOURCES.SPOTIFY
     }
 
     try {

--- a/src/api/listenlater/types.ts
+++ b/src/api/listenlater/types.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
+import { PODCAST_SOURCES } from '../../models/types';
 
 export const AddPodcastToListenLaterSchema = z.object({
     userId: z.string(),
     itemId: z.string(),
     channelId: z.string(),
-    source: z.string().nullable().default('itunes'),
+    source: z.string().nullable().default(PODCAST_SOURCES.SPOTIFY),
 })
 
 export type AddPodcastToListenLaterRequest = z.infer<typeof AddPodcastToListenLaterSchema>

--- a/src/api/playlist/playlist.ts
+++ b/src/api/playlist/playlist.ts
@@ -3,6 +3,7 @@ import { queryPlaylistByPlaylistId, queryPlaylistItemsByPlaylistId, queryUserPla
 import prisma from "../../db/prisma.client";
 import { FeedItem } from "../../models/feeds";
 import { UserPlaylistDto, UserPlaylistItemDto } from "../../models/playlist";
+import { PODCAST_SOURCES } from "../../models/types";
 import { generateFeedItemId, generatePlaylistId, generatePlaylistItemId } from "../../utils/common";
 import { getPodcastEpisodeInfo } from "../../utils/itunes";
 import { logger } from "../../utils/logger";
@@ -44,7 +45,7 @@ export async function addPodcastToPlaylist(playlistId: string, channelId: string
 
     let itemInfoResp;
     let feedItem: FeedItem
-    if (source == 'itunes') {
+    if (source == PODCAST_SOURCES.ITUNES) {
         itemInfoResp = await getPodcastEpisodeInfo(channelId, guid)
         feedItem = itemInfoResp.episode
     } else {

--- a/src/api/playlist/route.ts
+++ b/src/api/playlist/route.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { AddPodcastToPlaylistRequestData, AddPodcastToPlaylistSchema, CreatePlaylistRequestData, CreatePlaylistSchema } from "./types";
 import { addPodcastToPlaylist, createPlaylist, getPlaylistPodcastList, getUserPlaylistList } from "./playlist";
+import { PODCAST_SOURCES } from "../../models/types";
 
 
 export const playlistRoute = new Hono()
@@ -59,7 +60,7 @@ playlistRoute.post('/item', zValidator('json', AddPodcastToPlaylistSchema), asyn
 
     const body: AddPodcastToPlaylistRequestData = await c.req.json();
     try {
-        const message = await addPodcastToPlaylist(body.playlistId, body.channelId, body.source || 'itunes', body.guid)
+        const message = await addPodcastToPlaylist(body.playlistId, body.channelId, body.source || PODCAST_SOURCES.SPOTIFY, body.guid)
         return c.json({
             code: 0,
             msg: message

--- a/src/api/playlist/types.ts
+++ b/src/api/playlist/types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { PODCAST_SOURCES } from '../../models/types';
 
 export const CreatePlaylistSchema = z.object({
     userId: z.string(),
@@ -11,7 +12,7 @@ export type CreatePlaylistRequestData = z.infer<typeof CreatePlaylistSchema>
 export const AddPodcastToPlaylistSchema = z.object({
     playlistId: z.string(),
     channelId: z.string(),
-    source: z.string().nullable().default('itunes'),
+    source: z.string().nullable().default(PODCAST_SOURCES.SPOTIFY),
     guid: z.string(),
 })
 

--- a/src/api/subscribe/types.ts
+++ b/src/api/subscribe/types.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod';
+import { PODCAST_SOURCES } from '../../models/types';
 
 export const KeywordSubscribeSchema = z.object({
     userId: z.string(),
     keyword: z.string(),
     country: z.string().default('US'),
     excludeFeedId: z.string().optional(),
-    source: z.string().default('itunes'),
+    source: z.string().default(PODCAST_SOURCES.SPOTIFY),
     sortByDate: z.number().default(1),
 })
 

--- a/src/db/subscription.ts
+++ b/src/db/subscription.ts
@@ -7,6 +7,7 @@ import { searchPodcastEpisodeFromItunes } from "../utils/itunes";
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from "../utils/logger";
 import { searchSpotifyEpisodes } from "../utils/spotify";
+import { PODCAST_SOURCES } from "../models/types";
 
 
 export async function getAllUserSubscriptions(): Promise<SubscriptionDataDto[]> {
@@ -153,7 +154,7 @@ export async function recoredUserKeywordSubscription(userId: string, keyword: st
 
 export async function doSearchSubscription(keyword: string, country: string, source: string, excludeFeedId: string) {
     let searchResultItemList: FeedItem[] = [];
-    if (source == 'itunes' || source == '') {
+    if (source == PODCAST_SOURCES.ITUNES) {
         const searchResult = await searchPodcastEpisodeFromItunes(keyword, 'podcastEpisode', country, excludeFeedId, 0, 0, 200)
         searchResultItemList.push(...searchResult);
     } else {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,0 +1,67 @@
+/**
+ * Podcast source types supported by the application
+ */
+export const PODCAST_SOURCES = {
+    ITUNES: 'itunes',
+    SPOTIFY: 'spotify'
+} as const;
+
+/**
+ * Type representing valid podcast source values
+ */
+export type PodcastSource = typeof PODCAST_SOURCES[keyof typeof PODCAST_SOURCES];
+
+/**
+ * Get podcast source type from string value
+ * @param sourceString The source string to validate ('itunes', 'spotify', etc.)
+ * @returns PodcastSource if valid, null if invalid
+ */
+export function getPodcastSource(sourceString: string): PodcastSource | null {
+    if (!sourceString || typeof sourceString !== 'string') {
+        return null;
+    }
+
+    const normalized = sourceString.toLowerCase().trim();
+
+    switch (normalized) {
+        case PODCAST_SOURCES.ITUNES:
+            return PODCAST_SOURCES.ITUNES;
+        case PODCAST_SOURCES.SPOTIFY:
+            return PODCAST_SOURCES.SPOTIFY;
+        default:
+            return null;
+    }
+}
+
+/**
+ * Check if a string value is a valid podcast source
+ * @param sourceString The source string to validate
+ * @returns true if valid, false if invalid
+ */
+export function isValidPodcastSource(sourceString: string): boolean {
+    return getPodcastSource(sourceString) !== null;
+}
+
+/**
+ * Get display name for a podcast source
+ * @param source The podcast source
+ * @returns Human-readable display name
+ */
+export function getPodcastSourceDisplayName(source: PodcastSource): string {
+    switch (source) {
+        case PODCAST_SOURCES.ITUNES:
+            return 'iTunes';
+        case PODCAST_SOURCES.SPOTIFY:
+            return 'Spotify';
+        default:
+            return 'Unknown';
+    }
+}
+
+/**
+ * Array of all valid podcast source values
+ */
+export const VALID_PODCAST_SOURCES: readonly PodcastSource[] = [
+    PODCAST_SOURCES.ITUNES,
+    PODCAST_SOURCES.SPOTIFY
+] as const;

--- a/src/telegram/bot.handler.search.ts
+++ b/src/telegram/bot.handler.search.ts
@@ -7,6 +7,7 @@ import { getUserInfoByTelegramId } from '../db/user';
 import { logger } from '../utils/logger';
 import { SEARCH_COMMAND } from './bot.types';
 import { getSpotifyEpisodeDetail, getSpotifyShowDetail, searchSpotifyEpisodes } from '../utils/spotify';
+import { PODCAST_SOURCES } from '../models/types';
 
 
 export async function handleSearch(chatId: number, keyword: string, page: number = 0, messageId?: number): Promise<void> {
@@ -150,10 +151,10 @@ export async function handleSearchCallbackQuery(teleUserId : string, chatId: num
         const [keyword] = payload;
         try {
             const userInfo = await getUserInfoByTelegramId(teleUserId);
-            const result = await recordUserKeywordSubscription(userInfo.userId, keyword, 'itunes', 'US', '', 0);
+            const result = await recordUserKeywordSubscription(userInfo.userId, keyword, PODCAST_SOURCES.SPOTIFY, 'US', '', 0);
             let responseText = '';
             if (!result) {
-                await doSearchSubscription(keyword, 'US', 'itunes', '');
+                await doSearchSubscription(keyword, 'US', PODCAST_SOURCES.SPOTIFY, '');
                 responseText = `Successfully subscribed to "${keyword}"!`;
             } else {
                 responseText = result


### PR DESCRIPTION
…SOURCES constants

- Import PODCAST_SOURCES enum from models/types in listenlater and playlist modules
- Update conditionals and defaults to use PODCAST_SOURCES.ITUNES and PODCAST_SOURCES.SPOTIFY
- Change default source from 'itunes' to 'spotify' in listenlater and playlist APIs
- Improves code maintainability by centralizing source definitions and eliminating magic strings