### PR TITLE
fix: update user_subscription latest_id, update_time, total_count on initial keyword subscription

### DIFF
--- a/src/api/subscribe/subscribe.ts
+++ b/src/api/subscribe/subscribe.ts
@@ -29,8 +29,10 @@ export async function updateUserSubscription(request: KeywordSubscribeRequestDat
         return 'Already subscribed'
     }
 
+    let userSubscription: { id: string } | null = null
+
     try {
-        await prisma.user_subscription.create({
+        userSubscription = await prisma.user_subscription.create({
             data: {
                 id: uuidv4(),
                 user_id: userId,
@@ -61,6 +63,42 @@ export async function updateUserSubscription(request: KeywordSubscribeRequestDat
     } catch (error) {
         logger.error(String(error))
         return "Something went wrong, please try again later"
+    }
+
+    try {
+        const [latestKs, totalCount] = await Promise.all([
+            prisma.keyword_subscription.findFirst({
+                where: {
+                    keyword: keyword,
+                    source: source,
+                    country: country,
+                    exclude_feed_id: excludeFeedId
+                },
+                orderBy: { id: 'desc' },
+                select: { id: true, create_time: true }
+            }),
+            prisma.keyword_subscription.count({
+                where: {
+                    keyword: keyword,
+                    source: source,
+                    country: country,
+                    exclude_feed_id: excludeFeedId
+                }
+            })
+        ])
+
+        if (latestKs?.id) {
+            await prisma.user_subscription.update({
+                where: { id: userSubscription!.id },
+                data: {
+                    latest_id: latestKs.id,
+                    update_time: latestKs.create_time,
+                    total_count: totalCount
+                }
+            })
+        }
+    } catch (error) {
+        logger.error(String(error))
     }
 
     return 'done'


### PR DESCRIPTION
## Summary
- When a user first subscribes to a search keyword, feed items are now fetched and stored, and the parent `user_subscription` row is properly updated with `latest_id`, `update_time`, and `total_count`.
- This matches the pattern already used by the scheduled job (`user_sub_update.ts`), but without sending notifications on initial subscription.

## Changes
- `src/api/subscribe/subscribe.ts`: After `doSearchSubscription()` inserts records, query the latest `keyword_subscription` id/creation time and total count, then update the `user_subscription` record.