### PR TITLE
feat: add rate limiting to email OTP requests

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -5,6 +5,7 @@ import { logger } from '../../utils/logger';
 import type { AuthUser, VerifyOtpResult } from './types';
 
 const OTP_EXPIRY_MINUTES = 10;
+const RESEND_COOLDOWN_SECONDS = 60;
 const SESSION_EXPIRY_DAYS = 30;
 const SESSION_PREFIX_LENGTH = 12;
 
@@ -49,6 +50,20 @@ export function getBearerToken(authorizationHeader?: string | null): string | nu
 export async function createEmailOtpChallenge(email: string) {
   const db = prisma as unknown as AuthPrismaClient;
   const normalizedEmail = normalizeEmail(email);
+
+  const recentToken = await db.verification_token.findFirst({
+    where: { email: normalizedEmail },
+    orderBy: { created_at: 'desc' },
+  });
+
+  if (recentToken) {
+    const elapsed = Math.floor((Date.now() - (recentToken as any).created_at.getTime()) / 1000);
+    const remaining = RESEND_COOLDOWN_SECONDS - elapsed;
+    if (remaining > 0) {
+      throw new Error(`Resend too soon: ${remaining}`);
+    }
+  }
+
   const code = randomInt(0, 1_000_000).toString().padStart(6, '0');
   const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
 
@@ -70,7 +85,7 @@ export async function createEmailOtpChallenge(email: string) {
 
   return {
     expiresIn: OTP_EXPIRY_MINUTES * 60,
-    resendAfter: 60,
+    resendAfter: RESEND_COOLDOWN_SECONDS,
   };
 }
 

--- a/src/api/auth/route.ts
+++ b/src/api/auth/route.ts
@@ -7,13 +7,30 @@ export const authRouter = new Hono();
 
 authRouter.post('/email-otp/request', zValidator('json', EmailOtpRequestSchema), async (c) => {
   const body: EmailOtpRequestData = await c.req.json();
-  const data = await createEmailOtpChallenge(body.email);
 
-  return c.json({
-    code: 0,
-    msg: 'If the email is eligible, an OTP has been sent',
-    data,
-  });
+  try {
+    const data = await createEmailOtpChallenge(body.email);
+    return c.json({
+      code: 0,
+      msg: 'If the email is eligible, an OTP has been sent',
+      data,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : '';
+    if (msg.startsWith('Resend too soon:')) {
+      const retryAfter = parseInt(msg.split(':')[1].trim());
+      return c.json({
+        code: 1,
+        msg: `Please wait ${retryAfter} seconds and try again.`,
+        error: 'RATE_LIMITED',
+        retryAfter,
+      }, 429);
+    }
+    return c.json({
+      code: 1,
+      msg: msg || 'Failed to send verification code',
+    }, 500);
+  }
 });
 
 authRouter.post('/email-otp/verify', zValidator('json', EmailOtpVerifySchema), async (c) => {


### PR DESCRIPTION
## Summary
- Add 60-second cooldown between email OTP requests, enforced via `verification_token.created_at` check
- Return 429 with `error='RATE_LIMITED'` and `retryAfter` for structured client handling
- `msg` field preserved as English fallback for backwards compatibility

## Changes
- `src/api/auth/auth.ts` — check recent token timestamp before issuing new code
- `src/api/auth/route.ts` — catch rate limit error, return structured 429 response