### PR TITLE
feat: add membership API, webhook handler, and keyword limit enforcement

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -492,6 +492,25 @@ model user_subscription {
   @@schema("public")
 }
 
+model user_membership {
+  id                      String    @id @db.VarChar(64)
+  user_id                 String    @db.VarChar(64)
+  product_id              String    @db.VarChar(128)
+  tier                    String    @db.VarChar(32)
+  original_transaction_id String    @unique @db.VarChar(128)
+  latest_transaction_id   String?   @db.VarChar(128)
+  expires_date            DateTime? @db.Timestamp(6)
+  is_active               Boolean   @default(false)
+  will_renew              Boolean   @default(true)
+  is_in_billing_retry     Boolean   @default(false)
+  environment             String    @default("Production") @db.VarChar(16)
+  created_at              DateTime  @default(now()) @db.Timestamp(6)
+  updated_at              DateTime  @updatedAt @db.Timestamp(6)
+
+  @@index([user_id])
+  @@schema("public")
+}
+
 enum aal_level {
   aal1
   aal2

--- a/src/api/membership/membership.ts
+++ b/src/api/membership/membership.ts
@@ -1,0 +1,216 @@
+import prisma from "../../db/prisma.client"
+import { v4 as uuidv4 } from "uuid"
+import {
+  JWSTransactionDecoded,
+  MembershipStatusResult,
+  PRODUCT_TIER_MAP,
+  TIER_KEYWORDS_LIMIT,
+} from "./types"
+
+function decodeJWSPayload(signedTransaction: string): JWSTransactionDecoded {
+  const parts = signedTransaction.split(".")
+  if (parts.length < 3) {
+    throw new Error("Invalid JWS transaction: expected 3 parts")
+  }
+  const payloadEncoded = parts[1]
+  const payloadJson = atob(payloadEncoded)
+  const payload = JSON.parse(payloadJson)
+  return {
+    transactionId: payload.transactionId,
+    originalTransactionId: payload.originalTransactionId,
+    productId: payload.productId,
+    expiresDate: payload.expiresDate,
+    revocationDate: payload.revocationDate,
+    revocationReason: payload.revocationReason,
+    offerType: payload.offerType,
+    offerIdentifier: payload.offerIdentifier,
+    type: payload.type,
+    inAppOwnershipType: payload.inAppOwnershipType,
+    signedDate: payload.signedDate,
+    environment: payload.environment,
+  }
+}
+
+function resolveTier(productId: string): string {
+  return PRODUCT_TIER_MAP[productId] ?? "free"
+}
+
+export async function syncMembership(
+  signedTransaction: string,
+  environment: string
+): Promise<MembershipStatusResult> {
+  const decoded = decodeJWSPayload(signedTransaction)
+  const productId = decoded.productId
+  const tier = resolveTier(productId)
+  const originalTransactionId = decoded.originalTransactionId
+  const latestTransactionId = decoded.transactionId
+  const expiresDate = decoded.expiresDate
+    ? new Date(decoded.expiresDate)
+    : null
+  const isRevoked = decoded.revocationDate != null
+  const now = new Date()
+  const isActive = !isRevoked && expiresDate != null && expiresDate > now
+  const willRenew = decoded.offerType !== 1 // type 1 = introductory, but we check revocation instead
+
+  // Find the user who owns this transaction. For new purchases, we need userId from auth context.
+  // We'll look up existing membership by original_transaction_id.
+  // If not found, this is a new purchase — the route handler will extract userId from auth.
+  const existing = await prisma.user_membership.findUnique({
+    where: { original_transaction_id: originalTransactionId },
+  })
+
+  let userId: string
+  if (existing) {
+    userId = existing.user_id
+  } else {
+    // For new purchases, userId must be provided separately via route handler
+    throw new Error(
+      "Membership not found. Provide userId for new purchases."
+    )
+  }
+
+  const membershipData = {
+    user_id: userId,
+    product_id: productId,
+    tier,
+    original_transaction_id: originalTransactionId,
+    latest_transaction_id: latestTransactionId,
+    expires_date: expiresDate,
+    is_active: isActive,
+    will_renew: willRenew,
+    is_in_billing_retry: false,
+    environment,
+  }
+
+  if (existing) {
+    await prisma.user_membership.update({
+      where: { id: existing.id },
+      data: membershipData,
+    })
+  }
+
+  return getUserMembershipStatus(userId)
+}
+
+export async function syncMembershipForUser(
+  signedTransaction: string,
+  environment: string,
+  userId: string
+): Promise<MembershipStatusResult> {
+  const decoded = decodeJWSPayload(signedTransaction)
+  const productId = decoded.productId
+  const tier = resolveTier(productId)
+  const originalTransactionId = decoded.originalTransactionId
+  const latestTransactionId = decoded.transactionId
+  const expiresDate = decoded.expiresDate
+    ? new Date(decoded.expiresDate)
+    : null
+  const isRevoked = decoded.revocationDate != null
+  const now = new Date()
+  const isActive = !isRevoked && expiresDate != null && expiresDate > now
+
+  const existing = await prisma.user_membership.findFirst({
+    where: { original_transaction_id: originalTransactionId },
+  })
+
+  const membershipData = {
+    user_id: userId,
+    product_id: productId,
+    tier,
+    original_transaction_id: originalTransactionId,
+    latest_transaction_id: latestTransactionId,
+    expires_date: expiresDate,
+    is_active: isActive,
+    will_renew: true,
+    is_in_billing_retry: false,
+    environment,
+  }
+
+  if (existing) {
+    if (existing.user_id !== userId) {
+      throw new Error("Transaction belongs to a different user")
+    }
+    await prisma.user_membership.update({
+      where: { id: existing.id },
+      data: membershipData,
+    })
+  } else {
+    await prisma.user_membership.create({
+      data: {
+        id: uuidv4(),
+        ...membershipData,
+      },
+    })
+  }
+
+  return getUserMembershipStatus(userId)
+}
+
+export async function getUserMembershipStatus(
+  userId: string
+): Promise<MembershipStatusResult> {
+  const membership = await prisma.user_membership.findFirst({
+    where: {
+      user_id: userId,
+      is_active: true,
+      expires_date: { gt: new Date() },
+    },
+    orderBy: { expires_date: "desc" },
+  })
+
+  const keywordsUsed = await prisma.user_subscription.count({
+    where: { user_id: userId, status: 1 },
+  })
+
+  if (membership) {
+    const tier = membership.tier
+    return {
+      tier,
+      productId: membership.product_id,
+      expiresDate: membership.expires_date?.toISOString() ?? null,
+      isActive: true,
+      willRenew: membership.will_renew,
+      keywordsLimit: TIER_KEYWORDS_LIMIT[tier] ?? null,
+      keywordsUsed,
+    }
+  }
+
+  return {
+    tier: "free",
+    productId: null,
+    expiresDate: null,
+    isActive: false,
+    willRenew: false,
+    keywordsLimit: TIER_KEYWORDS_LIMIT["free"],
+    keywordsUsed,
+  }
+}
+
+export async function getUserTier(userId: string): Promise<string> {
+  const status = await getUserMembershipStatus(userId)
+  return status.tier
+}
+
+export async function getUserKeywordsLimit(
+  userId: string
+): Promise<number | null> {
+  const status = await getUserMembershipStatus(userId)
+  return status.keywordsLimit
+}
+
+export async function getUserKeywordsUsed(userId: string): Promise<number> {
+  const status = await getUserMembershipStatus(userId)
+  return status.keywordsUsed
+}
+
+export async function checkKeywordLimit(
+  userId: string
+): Promise<{ allowed: boolean; limit: number | null; used: number }> {
+  const status = await getUserMembershipStatus(userId)
+  const limit = status.keywordsLimit
+  const used = status.keywordsUsed
+  if (limit === null) {
+    return { allowed: true, limit: null, used }
+  }
+  return { allowed: used < limit, limit, used }
+}

--- a/src/api/membership/route.ts
+++ b/src/api/membership/route.ts
@@ -1,0 +1,68 @@
+import { zValidator } from "@hono/zod-validator"
+import { Hono } from "hono"
+import { SyncMembershipSchema } from "./types"
+import { syncMembershipForUser, getUserMembershipStatus } from "./membership"
+import { handleAppStoreNotification } from "./webhook"
+import { getBearerToken } from "../auth/auth"
+
+export const membershipRouter = new Hono()
+
+membershipRouter.post("/webhook/appstore", async (c) => {
+  try {
+    const body = await c.req.json()
+    const signedPayload = body.signedPayload
+    if (!signedPayload) {
+      return c.json({ code: 1, msg: "signedPayload is required" }, 400)
+    }
+
+    await handleAppStoreNotification(signedPayload)
+    return c.json({ code: 0, msg: "Notification processed" })
+  } catch (error) {
+    return c.json({ code: 1, msg: String(error) }, 500)
+  }
+})
+
+membershipRouter.post("/sync", zValidator("json", SyncMembershipSchema), async (c) => {
+  const body = c.req.valid("json")
+  const signedTransaction = body.signedTransaction
+  const environment = body.environment || "Production"
+
+  // Extract userId from Authorization header
+  const token = getBearerToken(c.req.header("Authorization") || "")
+  if (!token) {
+    return c.json({ code: 1, msg: "Authorization required" }, 401)
+  }
+
+  // We need userId. Get it from session lookup.
+  const prisma = (await import("../../db/prisma.client")).default
+  const crypto = await import("crypto")
+  const tokenHash = crypto.createHash("sha256").update(token).digest("hex")
+  const session = await prisma.app_session.findFirst({
+    where: { token_hash: tokenHash, revoked_at: null, expires_at: { gt: new Date() } },
+  })
+  if (!session) {
+    return c.json({ code: 1, msg: "Invalid session" }, 401)
+  }
+  const userId = session.user_id
+
+  try {
+    const status = await syncMembershipForUser(signedTransaction, environment, userId)
+    return c.json({ code: 0, msg: "Membership synced", data: status })
+  } catch (error) {
+    return c.json({ code: 1, msg: String(error) })
+  }
+})
+
+membershipRouter.get("/status", async (c) => {
+  const userId = c.req.query("userId")
+  if (!userId) {
+    return c.json({ code: 1, msg: "userId is required" })
+  }
+
+  try {
+    const status = await getUserMembershipStatus(userId)
+    return c.json({ code: 0, msg: "Success", data: status })
+  } catch (error) {
+    return c.json({ code: 1, msg: String(error) })
+  }
+})

--- a/src/api/membership/types.ts
+++ b/src/api/membership/types.ts
@@ -1,0 +1,42 @@
+import { z } from "zod"
+
+export const SyncMembershipSchema = z.object({
+  signedTransaction: z.string(),
+  environment: z.enum(["Sandbox", "Production"]).default("Production"),
+})
+
+export const TIER_KEYWORDS_LIMIT: Record<string, number | null> = {
+  free: 5,
+  pro: 20,
+  unlimited: null, // null = unlimited
+}
+
+export const PRODUCT_TIER_MAP: Record<string, string> = {
+  "podcastsearch.pro20": "pro",
+  "podcastsearch.unlimited": "unlimited",
+}
+
+export interface JWSTransactionDecoded {
+  transactionId: string
+  originalTransactionId: string
+  productId: string
+  expiresDate?: number // ms since 1970
+  revocationDate?: number
+  revocationReason?: number
+  offerType?: number
+  offerIdentifier?: string
+  type?: string // "Auto-Renewable Subscription"
+  inAppOwnershipType?: string
+  signedDate?: number
+  environment?: string
+}
+
+export interface MembershipStatusResult {
+  tier: string
+  productId: string | null
+  expiresDate: string | null
+  isActive: boolean
+  willRenew: boolean
+  keywordsLimit: number | null
+  keywordsUsed: number
+}

--- a/src/api/membership/webhook.ts
+++ b/src/api/membership/webhook.ts
@@ -1,0 +1,273 @@
+import prisma from "../../db/prisma.client"
+import { logger } from "../../utils/logger"
+import {
+  PRODUCT_TIER_MAP,
+  TIER_KEYWORDS_LIMIT,
+} from "./types"
+
+interface NotificationPayload {
+  notificationType: string
+  subtype?: string
+  notificationUUID: string
+  data?: {
+    bundleId: string
+    environment: string
+    signedTransactionInfo: string
+    signedRenewalInfo?: string
+  }
+  version?: string
+  signedDate?: number
+}
+
+interface TransactionInfo {
+  transactionId: string
+  originalTransactionId: string
+  productId: string
+  expiresDate?: number
+  revocationDate?: number
+  revocationReason?: number
+  type?: string
+  inAppOwnershipType?: string
+  signedDate?: number
+  offerType?: number
+  environment?: string
+}
+
+interface RenewalInfo {
+  originalTransactionId: string
+  autoRenewStatus?: number
+  autoRenewProductId?: string
+  expirationIntent?: number
+  isInBillingRetryPeriod?: boolean
+  signedDate?: number
+}
+
+function decodeJWSPayload<T>(signedPayload: string): T {
+  const parts = signedPayload.split(".")
+  if (parts.length < 3) {
+    throw new Error(`Invalid JWS: expected 3 parts, got ${parts.length}`)
+  }
+  const payloadEncoded = parts[1]
+  const payloadJson = atob(payloadEncoded)
+  return JSON.parse(payloadJson)
+}
+
+function resolveTier(productId: string): string {
+  return PRODUCT_TIER_MAP[productId] ?? "free"
+}
+
+export async function handleAppStoreNotification(
+  signedPayload: string
+): Promise<void> {
+  const notification = decodeJWSPayload<NotificationPayload>(signedPayload)
+
+  logger.info(
+    `App Store notification: type=${notification.notificationType} subtype=${notification.subtype ?? "none"} uuid=${notification.notificationUUID}`
+  )
+
+  const hasTransactionData =
+    notification.data?.signedTransactionInfo != null
+
+  if (!hasTransactionData) {
+    logger.info(
+      `App Store notification without transaction data, skipping: type=${notification.notificationType}`
+    )
+    return
+  }
+
+  const transactionInfo = decodeJWSPayload<TransactionInfo>(
+    notification.data!.signedTransactionInfo
+  )
+
+  const renewalInfo = notification.data?.signedRenewalInfo
+    ? decodeJWSPayload<RenewalInfo>(notification.data.signedRenewalInfo)
+    : null
+
+  const originalTransactionId = transactionInfo.originalTransactionId
+  const productId = transactionInfo.productId
+  const tier = resolveTier(productId)
+  const environment = transactionInfo.environment ?? "Production"
+
+  const membership = await prisma.user_membership.findUnique({
+    where: { original_transaction_id: originalTransactionId },
+  })
+
+  if (!membership) {
+    logger.warn(
+      `App Store notification for unknown transaction: originalTransactionId=${originalTransactionId} productId=${productId}`
+    )
+    return
+  }
+
+  switch (notification.notificationType) {
+    case "SUBSCRIBED":
+      await handleSubscribed(membership.id, transactionInfo, tier, environment)
+      break
+
+    case "DID_CHANGE_RENEWAL_STATUS":
+    case "DID_CHANGE_RENEWAL_PREF":
+      await handleRenewalChange(membership.id, transactionInfo, renewalInfo, tier)
+      break
+
+    case "DID_FAIL_TO_RENEW":
+      await handleFailedRenew(membership.id, transactionInfo)
+      break
+
+    case "DID_RENEW":
+      await handleRenew(membership.id, transactionInfo, tier)
+      break
+
+    case "EXPIRED":
+      await handleExpired(membership.id, transactionInfo)
+      break
+
+    case "REFUND":
+    case "REVOKE":
+      await handleRevocation(membership.id, transactionInfo)
+      break
+
+    case "OFFER_REDEEMED":
+      await handleSubscribed(membership.id, transactionInfo, tier, environment)
+      break
+
+    default:
+      logger.info(
+        `Unhandled notification type: ${notification.notificationType}`
+      )
+  }
+}
+
+async function handleSubscribed(
+  membershipId: string,
+  tx: TransactionInfo,
+  tier: string,
+  environment: string
+) {
+  const expiresDate = tx.expiresDate ? new Date(tx.expiresDate) : null
+  const isActive = tx.revocationDate == null && expiresDate != null && expiresDate > new Date()
+
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      tier,
+      product_id: tx.productId,
+      latest_transaction_id: tx.transactionId,
+      expires_date: expiresDate,
+      is_active: isActive,
+      will_renew: true,
+      is_in_billing_retry: false,
+      environment,
+    },
+  })
+
+  logger.info(`Membership subscribed: id=${membershipId} tier=${tier} expires=${expiresDate?.toISOString() ?? "none"}`)
+}
+
+async function handleRenew(
+  membershipId: string,
+  tx: TransactionInfo,
+  tier: string
+) {
+  const expiresDate = tx.expiresDate ? new Date(tx.expiresDate) : null
+  const isActive = expiresDate != null && expiresDate > new Date()
+
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      tier,
+      product_id: tx.productId,
+      latest_transaction_id: tx.transactionId,
+      expires_date: expiresDate,
+      is_active: isActive,
+      will_renew: true,
+      is_in_billing_retry: false,
+    },
+  })
+
+  logger.info(`Membership renewed: id=${membershipId} tier=${tier} expires=${expiresDate?.toISOString() ?? "none"}`)
+}
+
+async function handleRenewalChange(
+  membershipId: string,
+  tx: TransactionInfo,
+  renewal: RenewalInfo | null,
+  tier: string
+) {
+  const expiresDate = tx.expiresDate ? new Date(tx.expiresDate) : null
+  const isActive = tx.revocationDate == null && expiresDate != null && expiresDate > new Date()
+
+  // Handle upgrade/downgrade by checking if productId changed
+  const resolvedTier = tier
+  const resolvedProductId = renewal?.autoRenewProductId ?? tx.productId
+
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      tier: resolveTier(resolvedProductId),
+      product_id: resolvedProductId,
+      latest_transaction_id: tx.transactionId,
+      expires_date: expiresDate,
+      is_active: isActive,
+      will_renew: renewal?.autoRenewStatus === 1,
+      is_in_billing_retry: renewal?.isInBillingRetryPeriod ?? false,
+    },
+  })
+
+  logger.info(
+    `Membership renewal changed: id=${membershipId} productId=${resolvedProductId} willRenew=${renewal?.autoRenewStatus === 1}`
+  )
+}
+
+async function handleFailedRenew(
+  membershipId: string,
+  tx: TransactionInfo
+) {
+  const expiresDate = tx.expiresDate ? new Date(tx.expiresDate) : null
+
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      latest_transaction_id: tx.transactionId,
+      expires_date: expiresDate,
+      will_renew: false,
+      is_in_billing_retry: true,
+    },
+  })
+
+  logger.warn(`Membership renewal failed: id=${membershipId}`)
+}
+
+async function handleExpired(
+  membershipId: string,
+  tx: TransactionInfo
+) {
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      latest_transaction_id: tx.transactionId,
+      expires_date: tx.expiresDate ? new Date(tx.expiresDate) : undefined,
+      is_active: false,
+      will_renew: false,
+      is_in_billing_retry: false,
+    },
+  })
+
+  logger.info(`Membership expired: id=${membershipId}`)
+}
+
+async function handleRevocation(
+  membershipId: string,
+  tx: TransactionInfo
+) {
+  await prisma.user_membership.update({
+    where: { id: membershipId },
+    data: {
+      latest_transaction_id: tx.transactionId,
+      is_active: false,
+      will_renew: false,
+      is_in_billing_retry: false,
+    },
+  })
+
+  logger.info(`Membership revoked/refunded: id=${membershipId} reason=${tx.revocationReason ?? "unknown"}`)
+}

--- a/src/api/subscribe/subscribe.ts
+++ b/src/api/subscribe/subscribe.ts
@@ -6,6 +6,7 @@ import { FeedItem } from "../../models/feeds";
 import { doSearchSubscription, queryUserAllKeywordSubscriptionFeedItemList, queryUserKeywordSubscriptionList } from "../../db/subscription";
 import { SubscriptionDataDto } from "../../models/subscription";
 import { logger } from "../../utils/logger";
+import { checkKeywordLimit } from "../membership/membership";
 
 
 export async function updateUserSubscription(request: KeywordSubscribeRequestData): Promise<String> {
@@ -15,6 +16,12 @@ export async function updateUserSubscription(request: KeywordSubscribeRequestDat
     const excludeFeedId = request.excludeFeedId || ''
     const source = request.source
     const sortByDate = request.sortByDate
+
+    // Enforce keyword subscription limit based on membership tier
+    const limitCheck = await checkKeywordLimit(userId)
+    if (!limitCheck.allowed) {
+        return `Keyword subscription limit reached (${limitCheck.used}/${limitCheck.limit}). Upgrade to add more.`
+    }
 
     const userSubscriptionRecord = await prisma.user_subscription.findFirst({
         where: {

--- a/src/api/webhook/route.ts
+++ b/src/api/webhook/route.ts
@@ -1,0 +1,19 @@
+import { Hono } from "hono"
+import { handleAppStoreNotification } from "../membership/webhook"
+
+export const webhookRouter = new Hono()
+
+webhookRouter.post("/appstore", async (c) => {
+  try {
+    const body = await c.req.json()
+    const signedPayload = body.signedPayload
+    if (!signedPayload) {
+      return c.json({ code: 1, msg: "signedPayload is required" }, 400)
+    }
+
+    await handleAppStoreNotification(signedPayload)
+    return c.json({ code: 0, msg: "Notification processed" })
+  } catch (error) {
+    return c.json({ code: 1, msg: String(error) }, 500)
+  }
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { subscribeRouter } from './api/subscribe/route'
 import { playlistRoute } from './api/playlist/route'
 import { listenLaterRoute } from './api/listenlater/route'
 import { rssRoute } from './api/rss/route'
+import { membershipRouter } from './api/membership/route'
+import { webhookRouter } from './api/webhook/route'
 import { logger } from './utils/logger'
 import { printRoutesTable } from './utils/routes'
 
@@ -40,6 +42,8 @@ app.route('/api/subscribe', subscribeRouter)
 app.route('/api/playlist', playlistRoute)
 app.route('/api/listenlater', listenLaterRoute)
 app.route('/api/rss', rssRoute)
+app.route('/api/membership', membershipRouter)
+app.route('/api/webhook', webhookRouter)
 
 InitTelegramBot()
 IniteBakerJobs()


### PR DESCRIPTION
## Summary

- Added `user_membership` table to track user subscription tiers  
- Added `POST /api/membership/sync` — sync StoreKit transactions to backend  
- Added `GET /api/membership/status` — query user membership tier and keyword usage  
- Added `POST /api/webhook/appstore` — handle App Store Server Notifications V2:  
  `SUBSCRIBED`, `DID_RENEW`, `EXPIRED`, `DID_FAIL_TO_RENEW`, `REFUND`/`REVOKE`, renewal changes  
- Enforced keyword subscription limit in `POST /api/subscribe/keyword` based on tier

### Database Migration

```prisma
model user_membership {
  id                      String    @id
  user_id                 String
  product_id              String
  tier                    String    // "free" | "pro" | "unlimited"
  original_transaction_id String    @unique
  latest_transaction_id   String?
  expires_date            DateTime?
  is_active               Boolean
  will_renew              Boolean
  is_in_billing_retry     Boolean
  environment             String
  created_at              DateTime
  updated_at              DateTime
}
```

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/membership/sync` | Sync StoreKit transaction (auth required) |
| GET | `/api/membership/status?userId=` | Get user membership status |
| POST | `/api/webhook/appstore` | App Store Server Notification handler |

### Environment Variables

- `APP_BUNDLE_ID=com.guoshao.porkast`  
- `APP_STORE_SHARED_SECRET=` (configured in `.env`)