### PR TITLE
feat: add demo user OTP whitelist for App Store review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+DATABASE_URL=postgres://username:password@domain.com:54321/porkastdb
+RESEND_SUPPORT_API_KEY=resend_support_api_key
+RESEND_API_KEY=resend_api_key
+TELE_BOT_TOKEN=telegram_bot_token
+BOT_WEBHOOK_URL=https://domain.com/telegram/bot-webhook
+SPOTIFY_CLIENT_ID=spotify_client_id
+SPOTIFY_CLIENT_SECRET=spotify_client_secret
+TELE_MINI_APP_LINK=https://porkast-domain.com
+APP_BUNDLE_ID=com.test.domain
+APP_STORE_SHARED_SECRET=app_store_shared_secret
+DEMO_EMAILS=test@domain.com
+DEMO_CODE=xxxxxx

--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -46,10 +46,23 @@ export function getBearerToken(authorizationHeader?: string | null): string | nu
   return authorizationHeader.trim() || null;
 }
 
+function isDemoEmail(email: string): boolean {
+  const demoEmails = (process.env.DEMO_EMAILS || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  return demoEmails.includes(email);
+}
+
+function getDemoCode(): string {
+  return (process.env.DEMO_CODE || '000000').padStart(6, '0').slice(0, 6);
+}
+
 export async function createEmailOtpChallenge(email: string) {
   const db = prisma as unknown as AuthPrismaClient;
   const normalizedEmail = normalizeEmail(email);
-  const code = randomInt(0, 1_000_000).toString().padStart(6, '0');
+  const isDemo = isDemoEmail(normalizedEmail);
+  const code = isDemo ? getDemoCode() : randomInt(0, 1_000_000).toString().padStart(6, '0');
   const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
 
   await db.verification_token.deleteMany({
@@ -66,7 +79,11 @@ export async function createEmailOtpChallenge(email: string) {
     },
   });
 
-  await sendLoginOtpEmail(normalizedEmail, code, OTP_EXPIRY_MINUTES);
+  if (!isDemo) {
+    await sendLoginOtpEmail(normalizedEmail, code, OTP_EXPIRY_MINUTES);
+  } else {
+    logger.info(`Demo OTP requested for ${normalizedEmail}`);
+  }
 
   return {
     expiresIn: OTP_EXPIRY_MINUTES * 60,
@@ -133,6 +150,34 @@ export async function verifyEmailOtp(email: string, code: string, nickname?: str
         update_date: now,
       },
     });
+  }
+
+  // Auto-provision demo users with unlimited membership
+  if (isDemoEmail(normalizedEmail)) {
+    const demoTransactionId = `demo-${userInfo.id}`;
+    const demoExpires = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+    await prisma.user_membership.upsert({
+      where: { original_transaction_id: demoTransactionId },
+      create: {
+        id: randomUUID(),
+        user_id: userInfo.id,
+        product_id: 'podcastsearch.unlimited',
+        tier: 'unlimited',
+        original_transaction_id: demoTransactionId,
+        expires_date: demoExpires,
+        is_active: true,
+        will_renew: false,
+        environment: 'Development',
+      },
+      update: {
+        tier: 'unlimited',
+        product_id: 'podcastsearch.unlimited',
+        expires_date: demoExpires,
+        is_active: true,
+        will_renew: false,
+      },
+    });
+    logger.info(`Demo user ${normalizedEmail} auto-provisioned unlimited membership`);
   }
 
   const sessionToken = buildSessionToken();

--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -5,6 +5,7 @@ import { logger } from '../../utils/logger';
 import type { AuthUser, VerifyOtpResult } from './types';
 
 const OTP_EXPIRY_MINUTES = 10;
+const RESEND_COOLDOWN_SECONDS = 60;
 const SESSION_EXPIRY_DAYS = 30;
 const SESSION_PREFIX_LENGTH = 12;
 
@@ -61,6 +62,19 @@ function getDemoCode(): string {
 export async function createEmailOtpChallenge(email: string) {
   const db = prisma as unknown as AuthPrismaClient;
   const normalizedEmail = normalizeEmail(email);
+  const recentToken = await db.verification_token.findFirst({
+    where: { email: normalizedEmail },
+    orderBy: { created_at: 'desc' },
+  });
+
+  if (recentToken) {
+    const elapsed = Math.floor((Date.now() - (recentToken as any).created_at.getTime()) / 1000);
+    const remaining = RESEND_COOLDOWN_SECONDS - elapsed;
+    if (remaining > 0) {
+      throw new Error(`Resend too soon: ${remaining}`);
+    }
+  }
+
   const isDemo = isDemoEmail(normalizedEmail);
   const code = isDemo ? getDemoCode() : randomInt(0, 1_000_000).toString().padStart(6, '0');
   const expiresAt = new Date(Date.now() + OTP_EXPIRY_MINUTES * 60 * 1000);
@@ -87,7 +101,7 @@ export async function createEmailOtpChallenge(email: string) {
 
   return {
     expiresIn: OTP_EXPIRY_MINUTES * 60,
-    resendAfter: 60,
+    resendAfter: RESEND_COOLDOWN_SECONDS,
   };
 }
 

--- a/src/api/auth/route.ts
+++ b/src/api/auth/route.ts
@@ -7,13 +7,30 @@ export const authRouter = new Hono();
 
 authRouter.post('/email-otp/request', zValidator('json', EmailOtpRequestSchema), async (c) => {
   const body: EmailOtpRequestData = await c.req.json();
-  const data = await createEmailOtpChallenge(body.email);
 
-  return c.json({
-    code: 0,
-    msg: 'If the email is eligible, an OTP has been sent',
-    data,
-  });
+  try {
+    const data = await createEmailOtpChallenge(body.email);
+    return c.json({
+      code: 0,
+      msg: 'If the email is eligible, an OTP has been sent',
+      data,
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : '';
+    if (msg.startsWith('Resend too soon:')) {
+      const retryAfter = parseInt(msg.split(':')[1].trim());
+      return c.json({
+        code: 1,
+        msg: `Please wait ${retryAfter} seconds and try again.`,
+        error: 'RATE_LIMITED',
+        retryAfter,
+      }, 429);
+    }
+    return c.json({
+      code: 1,
+      msg: msg || 'Failed to send verification code',
+    }, 500);
+  }
 });
 
 authRouter.post('/email-otp/verify', zValidator('json', EmailOtpVerifySchema), async (c) => {


### PR DESCRIPTION
## Summary

Adds environment-configured demo user whitelist that bypasses email OTP delivery for App Store review test accounts.

## Changes

### `src/api/auth/auth.ts`

- **`isDemoEmail()`** — reads whitelist from `DEMO_EMAILS` env var (comma-separated)
- **`getDemoCode()`** — reads fixed OTP from `DEMO_CODE` env var (falls back to `000000`)
- **`createEmailOtpChallenge()`** — whitelisted emails use fixed code + skip `sendLoginOtpEmail()`
- **`verifyEmailOtp()`** — auto-provisions unlimited membership via `prisma.user_membership.upsert()` for whitelisted users

### Environment Variables

Add to deployment:

```
DEMO_EMAILS=sandboxuser@porkast.com
DEMO_CODE=123456
```

Multiple demo emails supported: `DEMO_EMAILS=a@b.com,c@d.com`

### App Store Connect Review Notes

```
Sign-in email: sandboxuser@porkast.com
Verification code: 123456
```