### PR TITLE
fix: resolve D1 queue subscription insert errors and Hogan EvalError

### DIFF
--- a/src/email/resend.ts
+++ b/src/email/resend.ts
@@ -1,6 +1,5 @@
 import { CreateEmailResponse, Resend } from "resend";
-import { NotificationParams } from "../models/subscription";
-import * as Hogan from 'hogan.js';
+import type { NotificationParams } from "../models/subscription";
 import { NOTIFICATION_TEMPLATE } from '../templates/notification';
 import { LOGIN_OTP_TEMPLATE } from '../templates/login-otp';
 
@@ -14,9 +13,25 @@ export function getResendInstance(apiKey: string) {
     return resendInstance
 }
 
+function renderTemplate(template: string, params: Record<string, any>): string {
+    let result = template
+    for (const [key, value] of Object.entries(params)) {
+        if (Array.isArray(value)) {
+            const sectionRegex = new RegExp(`{{#${key}}}([\\s\\S]*?){{\/${key}}}`, 'g')
+            result = result.replace(sectionRegex, (_, sectionContent) => {
+                return value.map((v: any) => sectionContent.replace(/{{\.}}/g, v)).join('')
+            })
+        } else {
+            const regex = new RegExp(`{{${key}}}`, 'g')
+            result = result.replace(regex, String(value ?? ''))
+        }
+    }
+    return result
+}
+
 export async function sendSubscriptionUpdateEmail(apiKey: string, params: NotificationParams): Promise<CreateEmailResponse> {
     const resend = getResendInstance(apiKey);
-    const htmlTempText = Hogan.compile(NOTIFICATION_TEMPLATE).render({
+    const htmlTempText = renderTemplate(NOTIFICATION_TEMPLATE, {
         keyword: params.keyword,
         nickname: params.nickname,
         updateCount: params.updateCount,
@@ -34,10 +49,7 @@ export async function sendSubscriptionUpdateEmail(apiKey: string, params: Notifi
 
 export async function sendLoginOtpEmail(apiKey: string, to: string, code: string, expiresMinutes: number): Promise<CreateEmailResponse> {
     const resend = getResendInstance(apiKey);
-    const htmlTempText = Hogan.compile(LOGIN_OTP_TEMPLATE).render({
-        code,
-        expiresMinutes
-    })
+    const htmlTempText = renderTemplate(LOGIN_OTP_TEMPLATE, { code, expiresMinutes })
 
     return resend.emails.send({
         from: 'Porkast <noreply@porkast.com>',

--- a/src/queues/subscription.ts
+++ b/src/queues/subscription.ts
@@ -12,6 +12,11 @@ import type { NotificationParams } from '../models/subscription'
 import type { FeedItem as FeedItemType } from '../models/feeds'
 import { PODCAST_SOURCES } from '../models/types'
 import type { Env, SubscriptionUpdateMessage } from '../env'
+function chunkArray<T>(arr: T[], size: number): T[][] {
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size))
+  return chunks
+}
 
 async function getLatestPubDateForSubscription(
   db: ReturnType<typeof createDb>,
@@ -80,7 +85,10 @@ export async function handleSubscriptionUpdate(
       const model = await buildFeedItemAndKeywordInputList(keyword, country, excludeFeedId, source, feedItemList)
 
       try {
-        await db.insert(keywordSubscription).values(model.keywordSubscriptionList)
+        const ksChunks = chunkArray(model.keywordSubscriptionList, 14)
+        for (const chunk of ksChunks) {
+          await db.insert(keywordSubscription).values(chunk)
+        }
       } catch (e: any) {
         if (e?.message?.includes('UNIQUE constraint failed')) {
           logger.warn('UNIQUE constraint violation for keyword_subscription, ignoring')
@@ -90,7 +98,10 @@ export async function handleSubscriptionUpdate(
       }
 
       try {
-        await db.insert(feedItem).values(model.feedItemList)
+        const fiChunks = chunkArray(model.feedItemList, 4)
+        for (const chunk of fiChunks) {
+          await db.insert(feedItem).values(chunk)
+        }
       } catch (e: any) {
         if (e?.message?.includes('UNIQUE constraint failed')) {
           logger.warn('UNIQUE constraint violation for feed_item, ignoring')

--- a/src/utils/itunes.ts
+++ b/src/utils/itunes.ts
@@ -3,6 +3,7 @@ import { convertMillsTimeToDuration, generateFeedItemId } from "./common"
 import { iTunesResponse, PodcastFeed, PodcastItem } from "../models/itunes"
 import Parser = require("rss-parser")
 import { logger } from "./logger"
+import { feedItem, keywordSubscription } from "../db/schema"
 
 
 export const searchPodcastEpisodeFromItunes = async (q: string, entity: string, country: string, excludeFeedId: string, offset: number, limit: number, totalCount: number): Promise<FeedItem[]> => {
@@ -79,47 +80,47 @@ export const searchPodcastEpisodeFromItunes = async (q: string, entity: string, 
     return items.slice(offset, offset + limit)
 }
 
-export const buildFeedItemAndKeywordInputList = async (keyword: string, country: string, excludeFeedIds: string, source: string, feedItemList: FeedItem[]): Promise<{ feedItemList: Prisma.feed_itemCreateManyInput[], keywordSubscriptionList: Prisma.keyword_subscriptionCreateManyInput[] }> => {
-    const feedItemCreateInputList: Prisma.feed_itemCreateManyInput[] = []
-    const keywordSubscriptionInputList: Prisma.keyword_subscriptionCreateManyInput[] = []
+export const buildFeedItemAndKeywordInputList = async (keyword: string, country: string, excludeFeedIds: string, source: string, feedItemList: FeedItem[]): Promise<{ feedItemList: typeof feedItem.$inferInsert[], keywordSubscriptionList: typeof keywordSubscription.$inferInsert[] }> => {
+    const feedItemCreateInputList: typeof feedItem.$inferInsert[] = []
+    const keywordSubscriptionInputList: typeof keywordSubscription.$inferInsert[] = []
 
 
     for (const item of feedItemList) {
         const itemId = await generateFeedItemId(item.FeedLink, item.Title)
         const channelId = await generateFeedItemId(item.FeedLink, item.ChannelTitle)
-        const feedItemInput: Prisma.feed_itemCreateManyInput = {
+        const feedItemInput: typeof feedItem.$inferInsert = {
             id: itemId,
-            channel_id: channelId,
-            feed_id: String(item.FeedId),
+            channelId: channelId,
+            feedId: String(item.FeedId),
             guid: item.GUID,
             title: item.Title,
             link: item.Link,
-            pub_date: new Date(item.PubDate),
+            pubDate: item.PubDate,
             author: item.Author,
-            input_date: new Date(),
-            image_url: item.ImageUrl,
-            enclosure_url: item.EnclosureUrl,
-            enclosure_type: item.EnclosureType,
-            enclosure_length: String(item.EnclosureLength),
+            inputDate: new Date().toISOString(),
+            imageUrl: item.ImageUrl,
+            enclosureUrl: item.EnclosureUrl,
+            enclosureType: item.EnclosureType,
+            enclosureLength: String(item.EnclosureLength),
             duration: item.Duration,
             episode: item.Episode,
             episodetype: item.EpisodeType,
             explicit: item.Explicit,
             season: item.Season,
-            description: Buffer.from(item.Description || '', 'utf8'),
-            channel_title: item.ChannelTitle,
-            feed_link: item.FeedLink,
+            description: new TextEncoder().encode(item.Description || ''),
+            channelTitle: item.ChannelTitle,
+            feedLink: item.FeedLink,
             source: item.Source,
         }
 
-        const keywordSubscriptionInput: Prisma.keyword_subscriptionCreateInput = {
+        const keywordSubscriptionInput: typeof keywordSubscription.$inferInsert = {
             keyword: keyword,
-            feed_channel_id: channelId,
-            feed_item_id: itemId,
-            create_time: new Date(),
+            feedChannelId: channelId,
+            feedItemId: itemId,
+            createTime: new Date().toISOString(),
             country: country,
             source: source,
-            exclude_feed_id: excludeFeedIds
+            excludeFeedId: excludeFeedIds,
         }
 
         feedItemCreateInputList.push(feedItemInput)


### PR DESCRIPTION

## Fixes

### 1. NOT NULL constraint failures (`keyword_subscription.feed_channel_id`, `feed_item.channel_id`)
- **src/utils/itunes.ts**: Converted Prisma-style snake_case keys to Drizzle-compatible camelCase in `buildFeedItemAndKeywordInputList()`. Also replaced `Buffer.from()` with `new TextEncoder().encode()` for Workers compatibility.

### 2. D1_DATE_ERROR: Date objects not supported
- **src/utils/itunes.ts**: Changed `new Date()` and `new Date(item.PubDate)` to ISO strings, since D1 doesn't accept JS Date objects.

### 3. too many SQL variables (D1 100-variable limit)
- **src/queues/subscription.ts**: Added `chunkArray()` helper and chunked inserts (keyword_subscription in batches of 14, feed_item in batches of 4) to stay under D1's 100-bind-variable limit.

### 4. EvalError: Code generation from strings disallowed
- **src/email/resend.ts**: Replaced `Hogan.compile().render()` with a custom `renderTemplate()` function using simple regex replacement, avoiding `new Function()` which Cloudflare Workers forbids.

## Testing
Verified locally with `wrangler dev --test-scheduled`: 92 keyword_subscription and 92 feed_item records inserted successfully with no errors.