### PR TITLE
fix: correct argument order in sendSubscriptionNewUpdateMessage call

### DIFF
--- a/src/queues/subscription.ts
+++ b/src/queues/subscription.ts
@@ -222,7 +222,7 @@ async function notifyUser(
       const link = `${env.TELE_MINI_APP_LINK}/subscription/${user.telegramId}/${keyword}`
 
       if (user.telegramId) {
-        sendSubscriptionNewUpdateMessage(user.telegramId, keyword, totalCount, ksList as any, link)
+        sendSubscriptionNewUpdateMessage(env.TELE_BOT_TOKEN, env.TELE_MINI_APP_LINK, user.telegramId, keyword, totalCount, ksList as any, link)
       }
 
       if (user.email) {


### PR DESCRIPTION
The function call was missing `env.TELE_BOT_TOKEN` and `env.TELE_MINI_APP_LINK` arguments and had the remaining arguments in the wrong order, causing `feedItemList` to be `undefined` and crash with `Cannot read properties of undefined (reading 'length')` when notifying users of subscription updates.