### PR TITLE
fix: allow optional whitespace in template variable placeholders

### DIFF
--- a/src/email/resend.ts
+++ b/src/email/resend.ts
@@ -22,7 +22,7 @@ function renderTemplate(template: string, params: Record<string, any>): string {
                 return value.map((v: any) => sectionContent.replace(/{{\.}}/g, v)).join('')
             })
         } else {
-            const regex = new RegExp(`{{${key}}}`, 'g')
+            const regex = new RegExp(`{{\\s*${key}\\s*}}`, 'g')
             result = result.replace(regex, String(value ?? ''))
         }
     }


### PR DESCRIPTION
The `renderTemplate` function generated regex like `{{code}}` (no spaces), but the templates use `{{ code }}` with spaces around the variable name. The regex failed to match, causing the placeholders to be sent literally in emails.

Fix: added `\s*` on both sides of the variable name in the regex to handle optional whitespace.