### PR TITLE
feat: reactivate user subscription on re-subscribe instead of inserting duplicate

### DIFF
--- a/src/api/subscribe/subscribe.ts
+++ b/src/api/subscribe/subscribe.ts
@@ -29,36 +29,46 @@ export async function updateUserSubscription(db: DbClient, request: KeywordSubsc
                 eq(userSubscription.userId, userId),
                 eq(userSubscription.keyword, keyword),
                 eq(userSubscription.source, source),
-                eq(userSubscription.status, 1),
             )
         )
         .limit(1)
 
+    let subId: string
+
     if (existing.length > 0) {
-        return 'Already subscribed'
-    }
-
-    const subId = crypto.randomUUID()
-
-    try {
-        await db.insert(userSubscription).values({
-            id: subId,
-            userId: userId,
-            keyword: keyword,
-            country: country,
-            source: source,
-            excludeFeedId: excludeFeedId,
-            orderByDate: sortByDate,
-            status: 1,
-            createTime: new Date().toISOString(),
-            type: 'searchKeyword',
-        })
-    } catch (error: any) {
-        if (error?.message?.includes('UNIQUE constraint failed')) {
+        if (existing[0].status === 1) {
             return 'Already subscribed'
         }
-        logger.error(String(error))
-        throw error
+        subId = existing[0].id
+        await db
+            .update(userSubscription)
+            .set({
+                status: 1,
+                updateTime: new Date().toISOString(),
+            })
+            .where(eq(userSubscription.id, subId))
+    } else {
+        subId = crypto.randomUUID()
+        try {
+            await db.insert(userSubscription).values({
+                id: subId,
+                userId: userId,
+                keyword: keyword,
+                country: country,
+                source: source,
+                excludeFeedId: excludeFeedId,
+                orderByDate: sortByDate,
+                status: 1,
+                createTime: new Date().toISOString(),
+                type: 'searchKeyword',
+            })
+        } catch (error: any) {
+            if (error?.message?.includes('UNIQUE constraint failed')) {
+                return 'Already subscribed'
+            }
+            logger.error(String(error))
+            throw error
+        }
     }
 
     try {


### PR DESCRIPTION
## What

When a user unsubscribes a search keyword (status → 0) then re-subscribes, the existing code created a duplicate subscription record. This change detects the inactive record and reactivates it by setting status back to 1.

## Changes

- Remove `status = 1` filter from the existing-record query in `updateUserSubscription`
- If existing record has status=0: update status to 1 (reactivate) instead of inserting new record
- If existing record has status=1: return 'Already subscribed' (unchanged)
- Limit check (`checkKeywordLimit`) still applies to both new and reactivated subscriptions
- `doSearchSubscription` + `latestId`/`totalCount` update runs for both paths