### PR TITLE
feat: route iTunes API calls through WebShare proxy

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -11,3 +11,4 @@ DEMO_CODE=000000
 NODE_ENV=development
 PODCAST_INDEX_API_KEY=your_podcast_index_api_key
 PODCAST_INDEX_API_SECRET=your_podcast_index_api_secret
+WEBSHARE_PROXY_URL=your_webshare_proxy_url

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "podcast": "^2.0.1",
         "resend": "^4.7.0",
         "rss-parser": "^3.13.0",
+        "undici": "^8.7.0",
         "zod": "^4.0.17",
       },
       "devDependencies": {
@@ -505,7 +506,7 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
-    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+    "undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -550,6 +551,8 @@
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "miniflare/undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "miniflare/workerd": ["workerd@1.20250906.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250906.0", "@cloudflare/workerd-darwin-arm64": "1.20250906.0", "@cloudflare/workerd-linux-64": "1.20250906.0", "@cloudflare/workerd-linux-arm64": "1.20250906.0", "@cloudflare/workerd-windows-64": "1.20250906.0" }, "bin": "bin/workerd" }, "sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "podcast": "^2.0.1",
     "resend": "^4.7.0",
     "rss-parser": "^3.13.0",
+    "undici": "^8.7.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/src/env.ts
+++ b/src/env.ts
@@ -16,6 +16,7 @@ export interface Env {
   DEMO_EMAILS: string
   DEMO_CODE: string
   NODE_ENV: string
+  WEBSHARE_PROXY_URL: string
 }
 
 export interface SubscriptionUpdateMessage {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import teleBot from './telegram/bot.hook'
 import { setupTelegramWebhook } from './telegram/bot.setup'
 import { setSpotifyCredentials } from './utils/spotify'
 import { setPodcastIndexCredentials } from './utils/podcast-index'
+import { initItunesProxy } from './utils/itunes'
 import type { Env } from './env'
 
 const app = new Hono<{ Bindings: Env }>()
@@ -31,6 +32,7 @@ app.use('*', dbMiddleware)
 app.use('*', async (c, next) => {
   setSpotifyCredentials(c.env.SPOTIFY_CLIENT_ID, c.env.SPOTIFY_CLIENT_SECRET)
   setPodcastIndexCredentials(c.env.PODCAST_INDEX_API_KEY, c.env.PODCAST_INDEX_API_SECRET)
+  initItunesProxy(c.env.WEBSHARE_PROXY_URL)
   await next()
 })
 

--- a/src/queues/subscription.ts
+++ b/src/queues/subscription.ts
@@ -1,7 +1,7 @@
 import { eq, and, desc, sql } from 'drizzle-orm'
 import { createDb } from '../db/client'
 import { userSubscription, userInfo, keywordSubscription, feedItem } from '../db/schema'
-import { searchPodcastEpisodeFromItunes, buildFeedItemAndKeywordInputList, ItunesRateLimitError } from '../utils/itunes'
+import { searchPodcastEpisodeFromItunes, buildFeedItemAndKeywordInputList, ItunesRateLimitError, initItunesProxy } from '../utils/itunes'
 import { searchSpotifyEpisodes } from '../utils/spotify'
 import { searchEpisodesFromPodcastIndex } from '../utils/podcast-index'
 import { logger } from '../utils/logger'
@@ -54,6 +54,7 @@ export async function handleSubscriptionUpdate(
   ctx: ExecutionContext
 ) {
   let rateLimited = false
+  initItunesProxy(env.WEBSHARE_PROXY_URL)
   for (const msg of batch.messages) {
     const { userId, keyword, country, source, excludeFeedId, latestId } = msg.body as SubscriptionUpdateMessage
 

--- a/src/utils/itunes.ts
+++ b/src/utils/itunes.ts
@@ -4,6 +4,15 @@ import { iTunesResponse, PodcastFeed, PodcastItem } from "../models/itunes"
 import Parser from "rss-parser"
 import { logger } from "./logger"
 import { feedItem, keywordSubscription } from "../db/schema"
+import { ProxyAgent, fetch as undiciFetch } from 'undici'
+
+let itunesFetch: typeof globalThis.fetch = globalThis.fetch
+
+export function initItunesProxy(proxyUrl: string): void {
+  if (!proxyUrl) return
+  const agent = new ProxyAgent(proxyUrl)
+  itunesFetch = ((url: string | URL | Request, init?: RequestInit) => undiciFetch(url as any, { ...init as any, dispatcher: agent })) as unknown as typeof globalThis.fetch
+}
 
 export class ItunesRateLimitError extends Error {
   retryAfter: number
@@ -26,7 +35,7 @@ async function checkItunesResponse(res: Response): Promise<void> {
 
 export const searchPodcastEpisodeFromItunes = async (q: string, entity: string, country: string, excludeFeedId: string, offset: number, limit: number, totalCount: number): Promise<FeedItem[]> => {
     const searchUrl = `https://itunes.apple.com/search?term=${q}&entity=${entity}&media=podcast&country=${country}&limit=${totalCount}`
-    const res = await fetch(searchUrl)
+    const res = await itunesFetch(searchUrl)
     logger.debug(`search url: ${searchUrl}`)
 
     await checkItunesResponse(res)
@@ -152,7 +161,7 @@ export const buildFeedItemAndKeywordInputList = async (keyword: string, country:
 }
 
 export const getPodcastEpisodeInfo = async (podcastId: string, episodeId: string): Promise<{ podcast: FeedChannel, episode: FeedItem }> => {
-    const res = await fetch(`https://itunes.apple.com/lookup?id=${podcastId}&entity=podcast`)
+    const res = await itunesFetch(`https://itunes.apple.com/lookup?id=${podcastId}&entity=podcast`)
     await checkItunesResponse(res)
     const jsonResp = await res.json() as { results?: Array<{ feedUrl?: string }> }
     const podcastInfo = jsonResp?.results?.[0]


### PR DESCRIPTION
## Summary
Route iTunes API calls through a WebShare HTTP proxy using `undici`'s `ProxyAgent` to avoid Cloudflare IP rate limiting/blocking by the iTunes API.

## Changes
- Add `undici` dependency for `ProxyAgent` support
- Create `initItunesProxy()` singleton in `src/utils/itunes.ts`
- Replace global `fetch` with `ProxyAgent`-backed fetch for both iTunes endpoints (search + lookup)
- Initialize proxy in HTTP middleware and queue handler
- Add `WEBSHARE_PROXY_URL` to `Env` interface, `.dev.vars`, and `.dev.vars.example`

## Production Note
`WEBSHARE_PROXY_URL` has been deployed as a Cloudflare Worker secret via `wrangler secret put`.