### PR TITLE
fix: replace undici ProxyAgent with manual CONNECT tunnel proxy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "podcast": "^2.0.1",
         "resend": "^4.7.0",
         "rss-parser": "^3.13.0",
-        "undici": "^8.7.0",
         "zod": "^4.0.17",
       },
       "devDependencies": {
@@ -506,7 +505,7 @@
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
-    "undici": ["undici@8.7.0", "", {}, "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ=="],
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
@@ -551,8 +550,6 @@
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "miniflare/undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "miniflare/workerd": ["workerd@1.20250906.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250906.0", "@cloudflare/workerd-darwin-arm64": "1.20250906.0", "@cloudflare/workerd-linux-64": "1.20250906.0", "@cloudflare/workerd-linux-arm64": "1.20250906.0", "@cloudflare/workerd-windows-64": "1.20250906.0" }, "bin": "bin/workerd" }, "sha512-ryVyEaqXPPsr/AxccRmYZZmDAkfQVjhfRqrNTlEeN8aftBk6Ca1u7/VqmfOayjCXrA+O547TauebU+J3IpvFXw=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "podcast": "^2.0.1",
     "resend": "^4.7.0",
     "rss-parser": "^3.13.0",
-    "undici": "^8.7.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/src/utils/itunes.ts
+++ b/src/utils/itunes.ts
@@ -4,14 +4,16 @@ import { iTunesResponse, PodcastFeed, PodcastItem } from "../models/itunes"
 import Parser from "rss-parser"
 import { logger } from "./logger"
 import { feedItem, keywordSubscription } from "../db/schema"
-import { ProxyAgent, fetch as undiciFetch } from 'undici'
+import { proxyFetch } from './proxy-fetch'
 
 let itunesFetch: typeof globalThis.fetch = globalThis.fetch
 
 export function initItunesProxy(proxyUrl: string): void {
   if (!proxyUrl) return
-  const agent = new ProxyAgent(proxyUrl)
-  itunesFetch = ((url: string | URL | Request, init?: RequestInit) => undiciFetch(url as any, { ...init as any, dispatcher: agent })) as unknown as typeof globalThis.fetch
+  itunesFetch = ((url: string | URL | Request, _init?: RequestInit) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url
+    return proxyFetch(urlStr, proxyUrl)
+  }) as unknown as typeof globalThis.fetch
 }
 
 export class ItunesRateLimitError extends Error {

--- a/src/utils/proxy-fetch.ts
+++ b/src/utils/proxy-fetch.ts
@@ -1,0 +1,125 @@
+import net from 'node:net'
+import tls from 'node:tls'
+
+interface HttpHeaders {
+  statusLine: string
+  headers: Map<string, string>
+  rest: Buffer
+}
+
+function readHttpHeaders(socket: net.Socket): Promise<HttpHeaders> {
+  const chunks: Buffer[] = []
+  return new Promise((resolve, reject) => {
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk)
+      const buf = Buffer.concat(chunks)
+      const idx = buf.indexOf('\r\n\r\n')
+      if (idx !== -1) {
+        socket.off('data', onData)
+        socket.off('error', onError)
+        const headerBlock = buf.toString('utf-8', 0, idx)
+        const lines = headerBlock.split('\r\n')
+        const statusLine = lines[0]
+        const headers = new Map<string, string>()
+        for (let i = 1; i < lines.length; i++) {
+          const colonIdx = lines[i].indexOf(':')
+          if (colonIdx > 0) {
+            headers.set(
+              lines[i].slice(0, colonIdx).trim().toLowerCase(),
+              lines[i].slice(colonIdx + 1).trim()
+            )
+          }
+        }
+        resolve({ statusLine, headers, rest: buf.subarray(idx + 4) })
+      }
+    }
+    const onError = (err: Error) => {
+      socket.off('data', onData)
+      reject(err)
+    }
+    socket.on('data', onData)
+    socket.on('error', onError)
+  })
+}
+
+function readRemaining(socket: net.Socket, initial: Buffer): Promise<Buffer> {
+  const chunks: Buffer[] = [initial]
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      socket.off('data', onData)
+      socket.off('end', onEnd)
+      socket.off('error', onError)
+    }
+    const onData = (chunk: Buffer) => chunks.push(chunk)
+    const onEnd = () => { cleanup(); resolve(Buffer.concat(chunks)) }
+    const onError = (err: Error) => { cleanup(); reject(err) }
+    socket.on('data', onData)
+    socket.on('end', onEnd)
+    socket.on('error', onError)
+  })
+}
+
+export async function proxyFetch(url: string, proxyUrl: string): Promise<Response> {
+  const proxyUrlObj = new URL(proxyUrl)
+  const proxyHost = proxyUrlObj.hostname
+  const proxyPort = parseInt(proxyUrlObj.port) || 80
+  const proxyAuth = proxyUrlObj.username
+    ? `${proxyUrlObj.username}:${proxyUrlObj.password}`
+    : null
+
+  const targetUrl = new URL(url)
+  const targetHost = targetUrl.hostname
+  const targetPort = parseInt(targetUrl.port) || 443
+
+  const socket = net.connect({ host: proxyHost, port: proxyPort })
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', resolve)
+    socket.once('error', reject)
+  })
+
+  let connectReq = `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n`
+  if (proxyAuth) {
+    connectReq += `Proxy-Authorization: Basic ${btoa(proxyAuth)}\r\n`
+  }
+  connectReq += '\r\n'
+  socket.write(connectReq)
+
+  const { statusLine: connectStatus } = await readHttpHeaders(socket)
+  const connectCode = parseInt(connectStatus.match(/^HTTP\/\d\.\d\s+(\d+)/)?.[1] || '0')
+  if (connectCode !== 200) {
+    socket.destroy()
+    throw new Error(`Proxy CONNECT failed: ${connectStatus}`)
+  }
+
+  const tlsSocket = tls.connect({
+    socket,
+    servername: targetHost,
+    rejectUnauthorized: false,
+  })
+  await new Promise<void>((resolve, reject) => {
+    tlsSocket.once('secureConnect', resolve)
+    tlsSocket.once('error', reject)
+  })
+
+  tlsSocket.write(
+    `GET ${targetUrl.pathname}${targetUrl.search} HTTP/1.1\r\n` +
+      `Host: ${targetHost}\r\n` +
+      `Accept: */*\r\n` +
+      `Connection: close\r\n` +
+      `\r\n`
+  )
+
+  const { statusLine, headers: respHeaders, rest } = await readHttpHeaders(tlsSocket as unknown as net.Socket)
+  const body = await readRemaining(tlsSocket as unknown as net.Socket, rest)
+
+  const statusMatch = statusLine.match(/^HTTP\/\d\.\d\s+(\d+)\s*(.*)/)
+  const status = parseInt(statusMatch?.[1] || '502')
+
+  const headers = new Headers()
+  for (const [k, v] of respHeaders) {
+    headers.set(k, v)
+  }
+
+  const ab = body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength) as ArrayBuffer
+  return new Response(ab, { status, statusText: statusMatch?.[2] || '' })
+}


### PR DESCRIPTION
Cloudflare Workers runtime lacks MessagePort, causing undici to fail at runtime. Replace with manual HTTP CONNECT tunnel implementation using node:net and node:tls (available via nodejs_compat flag).

- Remove undici dependency
- Add src/utils/proxy-fetch.ts: TCP CONNECT -> TLS handshake -> HTTP/1.1
- Update initItunesProxy to use proxyFetch instead of undici