### PR TITLE
fix: cloudflare:sockets proxy with startTls for iTunes API

### DIFF
--- a/src/utils/proxy-fetch.ts
+++ b/src/utils/proxy-fetch.ts
@@ -64,7 +64,10 @@ export async function proxyFetch(url: string, proxyUrl: string): Promise<Respons
   const targetHost = targetUrl.hostname
   const targetPort = parseInt(targetUrl.port) || 443
 
-  const socket = connect({ hostname: proxyHost, port: proxyPort })
+  const socket = connect(
+    { hostname: proxyHost, port: proxyPort },
+    { secureTransport: 'starttls', allowHalfOpen: false }
+  )
   await socket.opened
 
   let connectReq = `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\nHost: ${targetHost}:${targetPort}\r\n`


### PR DESCRIPTION
Use cloudflare:sockets connect() with secureTransport:'starttls' + startTls() to tunnel iTunes API through WebShare proxy. Avoids reader lock conflicts with node:net event-based API.