### PR TITLE
fix: improve iTunes proxy 502 error handling with ItunesProxyError and response body capture

### DIFF
--- a/src/utils/itunes.ts
+++ b/src/utils/itunes.ts
@@ -66,12 +66,9 @@ async function checkItunesResponse(res: Response): Promise<void> {
     throw new ItunesRateLimitError(retryAfter)
   }
   if (res.status === 502) {
-    let cause = 'Unknown proxy error'
-    try {
-      const body = await res.json() as { error?: string }
-      if (body?.error) cause = body.error
-    } catch {}
-    throw new ItunesProxyError(cause)
+    const body = await res.text()
+    logger.warn(`iTunes proxy 502 response body: ${body}`)
+    throw new ItunesProxyError(body)
   }
   if (!res.ok) {
     throw new Error(`iTunes API error: ${res.status} ${res.statusText}`)


### PR DESCRIPTION
## Changes

**Problem:** iTunes proxy container returns 502 when WEBSHARE proxy connection fails. All remaining iTunes messages in the batch cascade-fail without distinguishing proxy errors from other failures.

### Fixes

1. **New `ItunesProxyError` class** — on HTTP 502, throws a typed error instead of a generic `Error`
2. **proxyFailed flag** in queue handler — when a 502 occurs, remaining iTunes messages in the batch are immediately ack'd (skipped), letting the queue's `max_retries: 3` backoff handle the retry
3. **Read 502 body as text** — captures the raw Cloudflare Container infrastructure error message for debugging (was trying JSON parsing which failed silently, yielding 'Unknown proxy error')

## Files Changed

- `src/utils/itunes.ts` — +14 lines (ItunesProxyError class + 502 body reading)
- `src/queues/subscription.ts` — +9 lines/-2 lines (proxyFailed flag + skip iTunes messages on 502)