### PR TITLE
fix: remove @cloudflare/containers alias that broke container runtime in production

### DIFF
--- a/src/utils/itunes.ts
+++ b/src/utils/itunes.ts
@@ -66,12 +66,9 @@ async function checkItunesResponse(res: Response): Promise<void> {
     throw new ItunesRateLimitError(retryAfter)
   }
   if (res.status === 502) {
-    let cause = 'Unknown proxy error'
-    try {
-      const body = await res.json() as { error?: string }
-      if (body?.error) cause = body.error
-    } catch {}
-    throw new ItunesProxyError(cause)
+    const body = await res.text()
+    logger.warn(`iTunes proxy 502 response body: ${body}`)
+    throw new ItunesProxyError(body)
   }
   if (!res.ok) {
     throw new Error(`iTunes API error: ${res.status} ${res.statusText}`)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,9 +2,6 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "porkast-svc",
 	"main": "src/index.ts",
-	"alias": {
-		"@cloudflare/containers": "./src/containers/local-container-stub.ts"
-	},
 	"compatibility_date": "2025-05-14",
 	"compatibility_flags": [
 		"nodejs_compat"


### PR DESCRIPTION
The `alias` in `wrangler.jsonc` was replacing the built-in `@cloudflare/containers` module with `local-container-stub.ts` during **production deployment**, not just local dev. This caused every container fetch to return 502 with `"Container not available in local dev"`.